### PR TITLE
fix: rename function, update readme to add better warning

### DIFF
--- a/contracts/code-body-prover.clar
+++ b/contracts/code-body-prover.clar
@@ -70,7 +70,7 @@
 )
 
 ;; Returns (ok true) if the transaction was mined.
-(define-read-only (is-contract-deployed
+(define-read-only (was-contract-deploy-tx-mined
 	(nonce (buff 8))
 	(fee (buff 8))
 	(signature (buff 65))

--- a/tests/code-body-prover.test.ts
+++ b/tests/code-body-prover.test.ts
@@ -148,7 +148,7 @@ describe("code-body-prover.clar", () => {
 
 		response = simnet.callReadOnlyFn(
 			"code-body-prover",
-			"is-contract-deployed",
+			"was-contract-deploy-tx-mined",
 			[
 				bufferCV(tx_nonce_bytes),
 				bufferCV(tx_fee_bytes),


### PR DESCRIPTION
Rename the function to be more correct and add more detailed warning to the README.